### PR TITLE
run tsc -noemit on typescript files during lint-staged if 'isTypeScript"

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ add `@babel/preset-flow` to the `presets`-section.
 
 ### TypeScript Support
 
-If the `tsconfig.json`-file is present in the project root directory and the
+If the `tsconfig.json`-file is present in the project root directory and 
 `typescript` is a dependency the `@babel/preset-typescript` will automatically
 get loaded when you use the default babel config that comes with `kcd-scripts`.
 If you customised your `.babelrc`-file you might need to manually add
@@ -133,6 +133,8 @@ If you customised your `.babelrc`-file you might need to manually add
 
 `kcd-scripts` will automatically load any `.ts` and `.tsx` files, including the
 default entry point, so you don't have to worry about any rollup configuration.
+
+`tsc --noemit` will run during lint-staged to verify that files will compile.
 
 ## Inspiration
 

--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -1,4 +1,4 @@
-const {resolveKcdScripts, resolveBin} = require('../utils')
+const {resolveKcdScripts, resolveBin, ifTypescript} = require('../utils')
 
 const kcdScripts = resolveKcdScripts()
 const doctoc = resolveBin('doctoc')

--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -10,4 +10,5 @@ module.exports = {
     `${kcdScripts} lint`,
     `${kcdScripts} test --findRelatedTests`,
   ],
+  '*.+(ts|tsx)': ifTypescript ? [`tsc --noEmit`] : undefined
 }

--- a/src/config/lintstagedrc.js
+++ b/src/config/lintstagedrc.js
@@ -10,5 +10,5 @@ module.exports = {
     `${kcdScripts} lint`,
     `${kcdScripts} test --findRelatedTests`,
   ],
-  '*.+(ts|tsx)': ifTypescript ? [`tsc --noEmit`] : undefined
+  '*.+(ts|tsx)': ifTypescript ? [`tsc --noEmit`] : undefined,
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**
For TypeScript projects, developers would like to verify that their .ts and .tsx files compile in the lint-staged stop by running
`tsc -noemit`

<!-- Why are these changes necessary? -->

`Format`, `lint` and `test` were running on .ts and .tsc files, but nothing was checking that TypeScript code compiled correctly.

<!-- How were these changes implemented? -->
**How**
Used ifTypeScript from utils to check if TypeScript is enabled.  
If enabled, run `tsc --noEmilt` on all .ts and .tsx files

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

<!-- feel free to add additional comments -->
Testing
* Could not figure out the best way to test internally to the project, but tested in my own personal project.